### PR TITLE
Micro optimize setCustomAttribute call.

### DIFF
--- a/src/Traits/CustomAttributeTrait.php
+++ b/src/Traits/CustomAttributeTrait.php
@@ -311,21 +311,19 @@ trait CustomAttributeTrait
      * Sets an customAttributeValue with the given customAttribute name
      * and value
      * 
-     * @param int|string|Model $id
+     * @param int|string|Model $identifier
      * @param mixed $value
      * @param string $type default = null
      * 
      * @return mixed
      */
-    public function setCustomAttribute($attr, $value, $type = null) 
+    public function setCustomAttribute($identifier, $value, $type = null) 
     {
         try {
-            if ($attr instanceof Model) {
-                // do nothing
-            } else if ($this->hasCustomAttribute($attr)) {
-                $attr = $this->getCustomAttribute($attr);
-            } else {
-                $attr = $this->resolveCustomAttributeObject($attr);
+            $attr = $this->getCustomAttribute($identifier);
+
+            if ($attr === false) {
+                $this->resolveCustomAttributeObject($identifier);
             }
 
             if (is_null($value) && $attr->required) {


### PR DESCRIPTION
Micro optimization for `CustomAttributeTrait`.

The `setCustomAttribute` method had two fetches for the database for getting the custom attribute when the `$attr` wasn't a model and the attribute existed.

Now, the method just tries to resolve the attribute object by called `resolveCustomAttributeObject` in 3 ways.

1. Early return if we already have a `CustomAttribute`
2. Attempt to find it via the relationship in the method `getCustomAttribute` (which just actually checks if there is a `CustomAttributeValue` for the item tied to the `CustomAttribute` in question)
3. Last resort will just fetch the `CustomAttribute` from the actual table